### PR TITLE
Support requiring a call context for all calls

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,1 +1,1 @@
-* Adds support for specifying Application Name in the CallContext.
+* Add the ability to require calls to include CallContext.

--- a/src/Client/V2/Service/EmsApiService.cs
+++ b/src/Client/V2/Service/EmsApiService.cs
@@ -367,7 +367,13 @@ namespace EmsApi.Client.V2
                 return;
 
             if( !(args.Exception is ApiException apiEx) )
+            {
+                // If we got an EmsApiException already, then we should just rethrow that here.
+                if( args.Exception is EmsApiException )
+                    throw args.Exception;
+
                 throw new EmsApiException( args.Exception.Message, args.Exception );
+            }
 
             // Note: This object is a Dto.V2.Error, but in that class the messageDetail
             // field is marked as required, so it will not deserialize if the details

--- a/src/Client/V2/Service/EmsApiServiceConfiguration.cs
+++ b/src/Client/V2/Service/EmsApiServiceConfiguration.cs
@@ -118,6 +118,14 @@ namespace EmsApi.Client.V2
         public bool ThrowExceptionOnApiFailure { get; set; }
 
         /// <summary>
+        /// When true, the <seealso cref="EmsApiService"/> will throw an exception for
+        /// any API calls which do *not* have a CallContext passed into them.
+        /// This is useful in some scenarios where you want to enforce callers to provide a
+        /// call context to be more explicit.
+        /// </summary>
+        public bool RequireCallContext { get; set; }
+
+        /// <summary>
         /// Any customer headers that should be appended to a request. These are appended
         /// at the time of making the request so they can be altered on a per request basis.
         /// This is a good place to set the "X-Adi-Client-Username" and "X-Adi-Correlation-Id"
@@ -244,6 +252,7 @@ namespace EmsApi.Client.V2
                 ApplicationName = ApplicationName,
                 ThrowExceptionOnApiFailure = ThrowExceptionOnApiFailure,
                 ThrowExceptionOnAuthFailure = ThrowExceptionOnAuthFailure,
+                RequireCallContext = RequireCallContext,
                 CustomHeaders = CustomHeaders
             };
         }

--- a/src/Client/V2/Service/EmsApiServiceException.cs
+++ b/src/Client/V2/Service/EmsApiServiceException.cs
@@ -65,4 +65,15 @@ namespace EmsApi.Client.V2
         {
         }
     }
+
+    public class EmsApiNoCallContextException : EmsApiException
+    {
+        /// <summary>
+        /// Thrown when there is no CallContext provided and the service is configured to require one.
+        /// </summary>
+        public EmsApiNoCallContextException()
+            : base( "The EMS API was not provided a CallContext and one was expected.", innerException: null )
+        {
+        }
+    }
 }

--- a/src/Client/V2/Service/MessageHandler.cs
+++ b/src/Client/V2/Service/MessageHandler.cs
@@ -137,6 +137,8 @@ namespace EmsApi.Client.V2
             AddCustomHeaders( request.Headers );
 
             CallContext ctx = RetrieveCallContext( request );
+            if( ctx == null && m_serviceConfig.RequireCallContext )
+                throw new EmsApiNoCallContextException();
             AddCallContextHeaders( request.Headers, ctx );
 
             var authConfig = DetermineAuthMode( ctx );

--- a/src/Client/V2/Service/MessageHandler.cs
+++ b/src/Client/V2/Service/MessageHandler.cs
@@ -139,6 +139,7 @@ namespace EmsApi.Client.V2
             CallContext ctx = RetrieveCallContext( request );
             if( ctx == null && m_serviceConfig.RequireCallContext )
                 throw new EmsApiNoCallContextException();
+
             AddCallContextHeaders( request.Headers, ctx );
 
             var authConfig = DetermineAuthMode( ctx );

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>2.2.0</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Tests/ErrorHandlingTests.cs
+++ b/src/Tests/ErrorHandlingTests.cs
@@ -35,5 +35,15 @@ namespace EmsApi.Tests
             service.ServiceConfig.ThrowExceptionOnAuthFailure = false;
             service.EmsSystem.Get();
         }
+
+        [Fact( DisplayName = "Requiring a call context but not providing one should throw" )]
+        public void Require_call_context_but_dont_provide_one()
+        {
+            var config = m_config.Clone();
+            config.RequireCallContext = true;
+            using var service = new EmsApiService( config );
+            Action causeFailure = () => service.EmsSystem.Get();
+            causeFailure.Should().Throw<EmsApiException>();
+        }
     }
 }

--- a/src/Tests/ErrorHandlingTests.cs
+++ b/src/Tests/ErrorHandlingTests.cs
@@ -43,7 +43,7 @@ namespace EmsApi.Tests
             config.RequireCallContext = true;
             using var service = new EmsApiService( config );
             Action causeFailure = () => service.EmsSystem.Get();
-            causeFailure.Should().Throw<EmsApiException>();
+            causeFailure.Should().Throw<EmsApiNoCallContextException>();
         }
     }
 }


### PR DESCRIPTION
This will be used to support the EMS API usage mode where we want to use trusted and password auth in the same process. By requiring a call context we can help force the caller to consider which style of auth they want to use.