### PR TITLE
Austin.mcdaniel/allow null column updates

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,2 +1,2 @@
-# Release 2.9.1
-* Change the discrete field value dictionary to be keyed by long to support the city pair field
+# Release 2.9.2
+* Add a new column DTO (UpdateColumn) to allow for updating fields to null values.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.9.1</VersionPrefix>
+        <VersionPrefix>2.9.2</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Dto/Column.cs
+++ b/src/Dto/Column.cs
@@ -1,0 +1,17 @@
+namespace EmsApi.Dto.V2
+{
+    /// <summary>
+    /// Represents a column to be modified.
+    /// </summary>
+    public class UpdateColumn : Column
+    {
+        /// <summary>
+        /// The value for the field. This is an override of the generated  <see cref="Column.Value"/> property to allow for nulls.
+        /// After trying to get the EMS API swagger to support allowing nulls and/or manually setting the spec to make this field null-able
+        /// (https://stackoverflow.com/questions/55970499/change-nswagstudio-serialization-setting-to-allow-for-nulls)
+        /// this was the only solution that worked. 
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty( "value", Required = Newtonsoft.Json.Required.AllowNull )]
+        public new object Value { get; set; } = new object();
+    }
+}

--- a/src/Dto/EmsApi.Dto.csproj
+++ b/src/Dto/EmsApi.Dto.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <Compile Include="Column.cs" />
     <Compile Include="EmsApi.Dto.V2.cs" />
     <Compile Include="Field.cs" />
   </ItemGroup>


### PR DESCRIPTION
Enables clients to use the Database update request to set field values to null. Note: the backing field must support null values.