### PR TITLE
Add alias as an option to DatabaseQuery.SelectField

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,2 +1,2 @@
-# Release 2.13.0
-* Add the includeMetadata option for analytic group routes
+# Release 2.14.0
+* Add alias option to DatabaseQuery.SelectField() method for alternate field result naming.

--- a/src/Client/V2/Model/DatabaseQuery.cs
+++ b/src/Client/V2/Model/DatabaseQuery.cs
@@ -66,13 +66,14 @@ namespace EmsApi.Dto.V2
         /// <summary>
         /// Adds a field to be included in the select statement of the query.
         /// </summary>
-        public void SelectField( string fieldId, SelectColumnAggregate? aggregate = null, SelectColumnFormat? format = null )
+        public void SelectField( string fieldId, SelectColumnAggregate? aggregate = null, SelectColumnFormat? format = null, string alias = null )
         {
             var column = new SelectColumn
             {
                 FieldId = fieldId,
                 Aggregate = aggregate,
-                Format = format
+                Format = format,
+                Alias = alias
             };
 
             Raw.Select.Add( column );
@@ -139,7 +140,7 @@ namespace EmsApi.Dto.V2
                 Args = new Collection<FilterArgument>()
             };
 
-            foreach( var arg in arguments )
+            foreach( FilterArgument arg in arguments )
                 inner.Args.Add( arg );
 
             wrapper.Value = inner;

--- a/src/Client/V2/Model/DatabaseQuery.cs
+++ b/src/Client/V2/Model/DatabaseQuery.cs
@@ -66,7 +66,8 @@ namespace EmsApi.Dto.V2
         /// <summary>
         /// Adds a field to be included in the select statement of the query.
         /// </summary>
-        public void SelectField( string fieldId, SelectColumnAggregate? aggregate = null, SelectColumnFormat? format = null, string alias = null )
+        /// <returns>The newly added select column object.</returns>
+        public SelectColumn SelectField( string fieldId, SelectColumnAggregate? aggregate = null, SelectColumnFormat? format = null, string alias = null )
         {
             var column = new SelectColumn
             {
@@ -77,6 +78,7 @@ namespace EmsApi.Dto.V2
             };
 
             Raw.Select.Add( column );
+            return column;
         }
 
         /// <summary>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.13.0</VersionPrefix>
+        <VersionPrefix>2.14.0</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
This provides an alternate name for a field in the returned query results. The return type of `SelectField()` was also changed from `void` to `SelectColumn` so that the caller can easily make further changes to the select details.