### PR TITLE
Updates the version for the CallContext header changes. 

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,2 +1,2 @@
-# Release 2.18.0
-* Adds route to get incoming files to EMS with their current statuses.
+# Release 2.18.1
+* Enforces ASCII encoding for CallContext HTTP headers.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.18.0</VersionPrefix>
+        <VersionPrefix>2.18.1</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
This should have gone with the previous commit/pull request.