### PR TITLE
Pedro.martinez/add analytic export reprocess objects end point

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,2 +1,2 @@
-# Release 2.18.2
-* Fixes exception for null headers in the CallContext.
+# Release 2.19.0
+* Adds support for the Export Analytic Service Reprocess route.

--- a/src/Client/V2/Access/ExportServiceAccess.cs
+++ b/src/Client/V2/Access/ExportServiceAccess.cs
@@ -192,7 +192,7 @@ namespace EmsApi.Client.V2.Access
         /// The optional call context to include.
         /// </param>
         /// <returns></returns>
-        public virtual void ReprocessAnalyticExportServiceObjects( string serviceId, AnalyticExportReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
+        public virtual void ReprocessAnalyticExportServiceObjects( string serviceId, ReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
         {
             ReprocessAnalyticExportServiceObjectsAsync( serviceId, reprocessObjectsRequest, context ).Wait();
         }
@@ -207,7 +207,7 @@ namespace EmsApi.Client.V2.Access
         /// The optional call context to include.
         /// </param>
         /// <returns></returns>
-        public virtual Task ReprocessAnalyticExportServiceObjectsAsync( string serviceId, AnalyticExportReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
+        public virtual Task ReprocessAnalyticExportServiceObjectsAsync( string serviceId, ReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
         {
             return CallApiTask( api => api.ReprocessAnalyticExportServiceObjects( serviceId, reprocessObjectsRequest, context ) );
         }

--- a/src/Client/V2/Access/ExportServiceAccess.cs
+++ b/src/Client/V2/Access/ExportServiceAccess.cs
@@ -181,5 +181,35 @@ namespace EmsApi.Client.V2.Access
         {
             return CallApiTask( api => api.DeleteAnalyticExportService( serviceId, context ) );
         }
+
+        /// <summary>
+        /// Reprocess objects for an analytic export service.
+        /// </summary>
+        /// <param name="serviceId">
+        /// The unique identifier for the export service to reprocess objects.
+        /// </param>
+        /// <param name="context">
+        /// The optional call context to include.
+        /// </param>
+        /// <returns></returns>
+        public virtual void ReprocessAnalyticExportServiceObjects( string serviceId, AnalyticExportReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
+        {
+            ReprocessAnalyticExportServiceObjectsAsync( serviceId, reprocessObjectsRequest, context ).Wait();
+        }
+
+        /// <summary>
+        /// Reprocess objects for an analytic export service.
+        /// </summary>
+        /// <param name="serviceId">
+        /// The unique identifier for the export service to reprocess objects.
+        /// </param>
+        /// <param name="context">
+        /// The optional call context to include.
+        /// </param>
+        /// <returns></returns>
+        public virtual Task ReprocessAnalyticExportServiceObjectsAsync( string serviceId, AnalyticExportReprocessObjectsRequest reprocessObjectsRequest, CallContext context = null )
+        {
+            return CallApiTask( api => api.ReprocessAnalyticExportServiceObjects( serviceId, reprocessObjectsRequest, context ) );
+        }
     }
 }

--- a/src/Client/V2/IEmsApi.cs
+++ b/src/Client/V2/IEmsApi.cs
@@ -1161,7 +1161,7 @@ namespace EmsApi.Client.V2
         /// The unique identifier for the export service status to reprocess objects.
         /// </param>
         [Post( "/v2/ems-systems/1/exportsvc/analytic/{serviceId}/reprocess" )]
-        Task ReprocessAnalyticExportServiceObjects( string serviceId, [Body] ReprocessObjectsRequest reprocessObjectsRequest,  [Property] CallContext context = null );
+        Task ReprocessAnalyticExportServiceObjects( string serviceId, [Body] ReprocessObjectsRequest reprocessObjectsRequest, [Property] CallContext context = null );
 
         /// <summary>
         /// Returns the swagger specification as a raw JSON string.

--- a/src/Client/V2/IEmsApi.cs
+++ b/src/Client/V2/IEmsApi.cs
@@ -1161,7 +1161,7 @@ namespace EmsApi.Client.V2
         /// The unique identifier for the export service status to reprocess objects.
         /// </param>
         [Post( "/v2/ems-systems/1/exportsvc/analytic/{serviceId}/reprocess" )]
-        Task ReprocessAnalyticExportServiceObjects( string serviceId, [Body] AnalyticExportReprocessObjectsRequest reprocessObjectsRequest,  [Property] CallContext context = null );
+        Task ReprocessAnalyticExportServiceObjects( string serviceId, [Body] ReprocessObjectsRequest reprocessObjectsRequest,  [Property] CallContext context = null );
 
         /// <summary>
         /// Returns the swagger specification as a raw JSON string.

--- a/src/Client/V2/IEmsApi.cs
+++ b/src/Client/V2/IEmsApi.cs
@@ -1155,6 +1155,15 @@ namespace EmsApi.Client.V2
         Task DeleteAnalyticExportService( string serviceId, [Property] CallContext context = null );
 
         /// <summary>
+        /// Reprocess an analytic export service objects.
+        /// </summary>
+        /// <param name="serviceId">
+        /// The unique identifier for the export service status to reprocess objects.
+        /// </param>
+        [Post( "/v2/ems-systems/1/exportsvc/analytic/{serviceId}/reprocess" )]
+        Task ReprocessAnalyticExportServiceObjects( string serviceId, [Body] AnalyticExportReprocessObjectsRequest reprocessObjectsRequest,  [Property] CallContext context = null );
+
+        /// <summary>
         /// Returns the swagger specification as a raw JSON string.
         /// </summary>
         /// <param name="apiVersion">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.18.2</VersionPrefix>
+        <VersionPrefix>2.19.0</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Dto/ems-api.json
+++ b/src/Dto/ems-api.json
@@ -6937,6 +6937,64 @@
                 "deprecated": false
             }
         },
+        "/v2/ems-systems/{emsSystemId}/exportsvc/analytic/{serviceId}/reprocess": {
+            "post": {
+                "tags": [
+                    "Export Service APIs"
+                ],
+                "summary": "Reprocess Objects for an analytic export service.",
+                "operationId": "ExportService_ReprocessAnalyticExportServiceObjects",
+                "consumes": [
+                    "application/json",
+                    "text/json"
+                ],
+                "produces": [],
+                "parameters": [
+                    {
+                        "name": "emsSystemId",
+                        "in": "path",
+                        "description": "The unique identifier of the system containing the EMS service.",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    {
+                        "name": "serviceId",
+                        "in": "path",
+                        "description": "The unique identifier for the export (service) to enable.",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "reprocessObjectsRequest",
+                        "in": "body",
+                        "description": "Represents the options used to reprocess an export service objects.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Adi.Ems.Web.Api.V2.Dto.ExportService.Analytic.ReprocessObjectsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "You do not have access to the requested resource.",
+                        "schema": {
+                            "$ref": "#/definitions/Adi.Ems.Web.Api.Model.Error"
+                        }
+                    },
+                    "503": {
+                        "description": "The maximum number of concurrent requests has been reached.",
+                        "schema": {
+                            "$ref": "#/definitions/Adi.Ems.Web.Api.Model.Error"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/v2/html-documentation/{version}": {
             "get": {
                 "tags": [
@@ -12968,6 +13026,23 @@
                     "format": "date-time",
                     "description": "The estimated completion time for all waiting exports",
                     "type": "string"
+                }
+            }
+        },
+        "Adi.Ems.Web.Api.V2.Dto.ExportService.Analytic.ReprocessObjectsRequest": {
+            "description": "Represents the options used to reprocess an export service objects.",
+            "required": [
+                "databaseId"
+            ],
+            "type": "object",
+            "properties": {
+                "databaseId": {
+                    "description": "The identifier of the database on which the analytics are based.",
+                    "type": "string"
+                },
+                "filtering": {
+                    "$ref": "#/definitions/Adi.Ems.Web.Api.V2.Dto.Schema.Filter",
+                    "description": "Empty if we are to reprocess everything, otherwise this will be a stringitized filter string for selectively reprocessing."
                 }
             }
         },


### PR DESCRIPTION
Add route to support object reprocessing of Analytic Export activity, so the client can request this action using filters or do full reprocess if no filter is provided.