### PR TITLE
Add route to search for analytics by fleet to be used in EDC.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,2 +1,2 @@
-# Release 2.22.0
-* Add routes to get analytic groups by fleet
+# Release 2.23.0
+* Add route to search for analytics by fleet.

--- a/src/Client/V2/Access/AnalyticsAccess.cs
+++ b/src/Client/V2/Access/AnalyticsAccess.cs
@@ -34,6 +34,13 @@ namespace EmsApi.Client.V2.Access
             return CallApiTask( api => api.GetAnalytics( text, groupId, maxResults, category, context ) );
         }
 
+        public virtual Task<IEnumerable<AnalyticInfo>> SearchAsync( AnalyticContext analyticContext, string text, string groupId = null, int? maxResults = null, Category category = Category.Full, CallContext context = null )
+        {
+            return analyticContext.Type == AnalyticContextType.Flight
+                ? CallApiTask( api => api.GetAnalyticsWithFlight( analyticContext.Id, text, groupId, maxResults, category, context ) )
+                : CallApiTask( api => api.GetAnalyticsWithFleet( analyticContext.Id, text, groupId, maxResults, category, context ) );
+        }
+
         /// <summary>
         /// Searches for analytics by name.
         /// </summary>
@@ -113,6 +120,33 @@ namespace EmsApi.Client.V2.Access
         public virtual IEnumerable<AnalyticInfo> Search( int flightId, string text, string groupId = null, int? maxResults = null, Category category = Category.Full, CallContext context = null )
         {
             return SafeAccessEnumerableTask( SearchAsync( flightId, text, groupId, maxResults, category, context ) );
+        }
+
+        /// <summary>
+        ///  Searches for analytics by name for an context resolvable.
+        /// </summary>
+        /// <param name="analyticContext">The resolvable context to look into, can be a flight or a fleet.</param>
+        /// <param name="text">
+        /// The search terms used to find a list of analytics by name.
+        /// </param>
+        /// <param name="groupId">
+        /// An optional group ID to specify where to limit the search. If not specified, all groups are searched.
+        /// </param>
+        /// <param name="maxResults">
+        /// The optional maximum number of matching results to return. If not specified, a default value of 200
+        /// is used. Use 0 to return the maximum of 1000 results.
+        /// </param>
+        /// <param name="category">
+        /// The category of analytics to search, including "Full", "Physical" or "Logical". A null value specifies
+        /// the default analytic set, which represents the full set of values exposed by the backing EMS system.
+        /// </param>
+        /// <param name="context">
+        /// The optional call context to include.
+        /// </param>
+        /// <returns></returns>
+        public virtual IEnumerable<AnalyticInfo> Search( AnalyticContext analyticContext, string text, string groupId = null, int? maxResults = null, Category category = Category.Full, CallContext context = null )
+        {
+            return SafeAccessEnumerableTask( SearchAsync( analyticContext, text, groupId, maxResults, category, context ) );
         }
 
         /// <summary>

--- a/src/Client/V2/IEmsApi.cs
+++ b/src/Client/V2/IEmsApi.cs
@@ -286,6 +286,22 @@ namespace EmsApi.Client.V2
         Task<IEnumerable<AnalyticInfo>> GetAnalyticsWithFlight( int flightId, string text, string group = null, int? maxResults = null, Category category = Category.Full, [Property] CallContext context = null );
 
         /// <summary>
+		/// Searches for analytics by name for a specific fleet.
+		/// </summary>
+		/// <param name="emsSystemId">The unique identifier of the system containing the EMS data.</param>
+		/// <param name="fleetId">The integer ID of the fleet to use when searching analytics.</param>
+		/// <param name="text">The search terms used to find a list of analytics by name.</param>
+		/// <param name="group">An optional group ID to specify where to limit the search. If not specified, all groups are searched.</param>
+		/// <param name="maxResults">The optional maximum number of matching results to return. If not specified, a 
+		/// default value of 200 is used. Use 0 to return all results.</param>
+		/// <param name="category">The category of analytics to search, including "Full", "Physical" or "Logical". A 
+		/// null value specifies the default analytic set, which represents the full set of values exposed by the 
+		/// backing EMS system.
+        /// </param>
+        [Get( "/v2/ems-systems/1/fleets/{fleetId}/analytics" )]
+        Task<IEnumerable<AnalyticInfo>> GetAnalyticsWithFleet( int fleetId, string text, string group = null, int? maxResults = null, Category category = Category.Full, [Property] CallContext context = null );
+
+        /// <summary>
         /// Retrieves metadata information associated with an analytic such as a description or units.
         /// </summary>
         /// <param name="analyticId">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.22.0</VersionPrefix>
+        <VersionPrefix>2.23.0</VersionPrefix>
         <VersionSuffix>prerelease</VersionSuffix>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Dto/ems-api.json
+++ b/src/Dto/ems-api.json
@@ -3681,6 +3681,96 @@
         "deprecated": false
       }
     },
+    "/v2/ems-systems/{emsSystemId}/fleets/{fleetId}/analytics": {
+      "get": {
+        "tags": [
+          "Analytic APIs"
+        ],
+        "summary": "Searches for analytics by name for a specific fleet.",
+        "operationId": "Analytic_SearchForFleetAnalytics",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "emsSystemId",
+            "in": "path",
+            "description": "The unique identifier of the system containing the EMS data.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "fleetId",
+            "in": "path",
+            "description": "The integer ID of the fleet to use when searching analytics.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "description": "The search terms used to find a list of analytics by name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group",
+            "in": "query",
+            "description": "An optional group ID to specify where to limit the search. If not specified, all groups are searched.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "The optional maximum number of matching results to return. If not specified, a \r\n            default value of 200 is used. Use 0 to return all results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "The category of analytics to search, including \"Full\", \"Physical\" or \"Logical\". A \r\n            null value specifies the default analytic set, which represents the full set of values exposed by the \r\n            backing EMS system.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "full",
+              "physical",
+              "logical"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Adi.Ems.Web.Api.V2.Dto.AnalyticInfo"
+              }
+            }
+          },
+          "401": {
+            "description": "You do not have access to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/Adi.Ems.Web.Api.Model.Error"
+            }
+          },
+          "503": {
+            "description": "The maximum number of concurrent requests has been reached.",
+            "schema": {
+              "$ref": "#/definitions/Adi.Ems.Web.Api.Model.Error"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
     "/v2/ems-systems/{emsSystemId}/analytic-set-groups": {
       "get": {
         "tags": [
@@ -10832,7 +10922,7 @@
           "type": "integer"
         },
         "type": {
-          "description": "Resolvable type from ResolvableType enum: FlightId, AircraftId or FleetId.",
+          "description": "Resolvable type from ResolvableType enum: FlightId or FleetId.",
           "enum": [
             "flight",
             "fleet"


### PR DESCRIPTION
Add route to search for analytics by fleet to be used in EDC.

This route supports to receive an Analytic context object.